### PR TITLE
Differentiate `Rule` typing, cleanup

### DIFF
--- a/ast/mod.ts
+++ b/ast/mod.ts
@@ -1,3 +1,3 @@
 export type { AST } from "./ast.ts";
-export type { Rule, Decl } from "./node.ts";
+export type { Rule, Decl, AtRule, SelectorRule } from "./node.ts";
 export type { Position, Token } from "./token.ts";

--- a/ast/node.ts
+++ b/ast/node.ts
@@ -1,16 +1,72 @@
 import type { Position } from "./token.ts";
 
-export interface Rule {
-  type: string;
-  text?: string;
-  selectors: string[];
-  declarations: Decl[];
-  prefix?: string;
-  position?: Position;
-}
+export type NodeType =
+  | "rule"
+  | "keyframes"
+  | "media"
+  | "charset"
+  | "import"
+  | "font-face"
+  | "viewport"
+  | "page"
+  | "supports"
+  | "document"
+  | "property"
+  | "comment";
+export type Node = {
+  type: NodeType;
 
-export interface Decl {
-  type?: string;
-  name?: string;
-  value?: string;
-}
+  position?: Position;
+};
+
+export type SelectorRule =
+  & Node
+  & {
+    type: "rule";
+
+    selectors: string[];
+    declarations: Decl[];
+    prefix?: string;
+  };
+
+export type AtRule =
+  & Node
+  & (
+    | {
+      type: "keyframes" | "media";
+
+      name: string;
+      prefix?: string;
+      rules: SelectorRule[];
+    }
+    | {
+      type: "charset" | "import";
+
+      name: string;
+      value: string;
+    }
+    | {
+      type: "font-face" | "viewport" | "page" | "supports" | "document";
+
+      prefix?: string;
+      declarations: Decl[];
+    }
+  );
+
+export type Decl =
+  & Node
+  & (
+    | {
+      type: "property";
+
+      name?: string;
+      value?: string;
+    }
+    | {
+      type: "comment";
+
+      text: string;
+    }
+  );
+
+export type Rule = SelectorRule | AtRule | Decl;

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,3 @@
-export type { AST, Rule, Decl, Position, Token } from "./ast/mod.ts";
+export type { AST, Rule, Decl, SelectorRule, AtRule, Position, Token } from "./ast/mod.ts";
 export { lex } from "./core/lexer/lexer.ts";
 export { parse } from "./core/parser/parser.ts";


### PR DESCRIPTION
Augmented rule types for typescript.

Cleanup parser, use correct types and idiomatic ES6
